### PR TITLE
Less downloading, more querying

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ $client = new B2Service($account_id, $application_key);
 //Authenticate with server. Anyway, all methods will ensure the authorization.
 $client->authorize()
 
-//Check if file exist in bucket
+// Returns true if bucket exists
 $client->isBucketExist($bucketId)
 
 //Returns the bucket information array.
@@ -67,8 +67,8 @@ $client->rename($bucketName, null, $fileName, $targetBucketId, $newFileName, $pr
 //Returns the list of files in bucket.
 $client->all($bucketId)
 
-// Returns true if bucket exist
-$client->exist($bucketName, $fileName)
+//Check if the file exists in a bucket
+$client->exists($bucketId, $fileName)
 
 ```
 

--- a/src/B2Backblaze/B2Service.php
+++ b/src/B2Backblaze/B2Service.php
@@ -289,15 +289,15 @@ class B2Service
      *
      * @return bool
      */
-    public function exists($bucketName, $fileName)
+    public function exists($bucketId, $fileName)
     {
         $this->ensureAuthorized();
-        $response = $this->client->b2DownloadFileByName($this->downloadURL, $bucketName, $fileName, $this->token, true);
+        $response = $this->client->b2ListFileNames($this->apiURL, $this->token, $bucketId, $fileName, 1);
         if (!$response->isOk(false)) {
             return false;
         }
 
-        return $response->getHeader('x-bz-file-name') == $fileName;
+        return $response->get('files')[0]['fileName'] === $fileName;
     }
 
     private function isAuthorized()


### PR DESCRIPTION
To check whether the file exists, ->exists() method in B2Service downloads the whole thing (and you get billed for it, every time!). So this version is just querying the API to check whether the file is there or not, without the unnecessary downloads.